### PR TITLE
Node version fixed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:12-alpine
 
 RUN mkdir -p /opt/app
 WORKDIR /app


### PR DESCRIPTION
The version number must be determined because in each new version, the project must not automatically move to that version.